### PR TITLE
Begin support for accepting repository references

### DIFF
--- a/lib/machine/codeSnippetInline.ts
+++ b/lib/machine/codeSnippetInline.ts
@@ -67,6 +67,10 @@ export const RefMicrogrammar: Microgrammar<SnippetReference> = microgrammar({
             filepath: /[^#]*/,
             _hash: "#",
             snippetName: /\S*/,
+            repoRef: optional(microgrammar({
+                phrase: `@\${repoOwner}/\${repoName}`,
+                terms: { repoOwner: /\S+/, repoName: /\S+/ },
+            })),
         },
         middle: takeUntil("<!-- atomist:"),
         snippetComment: optional(microgrammar({
@@ -127,16 +131,16 @@ export const CodeSnippetInlineTransform: CodeTransform = async (p, papi) => {
             async function whatToSubstitute(sampleFileUrl: string,
                                             snippetName: string,
                                             sampleFileHttpUrl: string): Promise<{
-                do: "replace" | "sampleFileNotFound" | "snippetNotFound",
-                commentContent: string,
-                snippetContent?: string,
-                link?: string, // html to link to source
-            }> {
+                    do: "replace" | "sampleFileNotFound" | "snippetNotFound",
+                    commentContent: string,
+                    snippetContent?: string,
+                    link?: string, // html to link to source
+                }> {
                 const sampleResponse = (await httpClient.exchange<string>(
                     sampleFileUrl,
                     { method: HttpMethod.Get }).catch(err =>
-                    // I don't know what is really returned here
-                    ({ body: undefined, status: err.message })));
+                        // I don't know what is really returned here
+                        ({ body: undefined, status: err.message })));
                 if (!sampleResponse.body) {
                     logger.error(
                         `Failed to retrieve ${sampleFileUrl}: status ${sampleResponse.status}`);

--- a/lib/machine/codeSnippetInline.ts
+++ b/lib/machine/codeSnippetInline.ts
@@ -66,7 +66,7 @@ export const RefMicrogrammar: Microgrammar<SnippetReference> = microgrammar({
         href: {
             filepath: /[^#]*/,
             _hash: "#",
-            snippetName: /\S*/,
+            snippetName: /[^@\s]*/,
             repoRef: optional(microgrammar({
                 phrase: `@\${repoOwner}/\${repoName}`,
                 terms: { repoOwner: /\S+/, repoName: /\S+/ },

--- a/test/machine/codeSnippetInline.test.ts
+++ b/test/machine/codeSnippetInline.test.ts
@@ -216,7 +216,14 @@ function parseSnippetReferences(p: Project, filename: string): SnippetReference[
     return results.map(match => toValueStructure<SnippetReference>(match));
 }
 
-function generatorMarkdown(snippetName: string = "dotnetGenerator", sampleFilepath: string = "lib/sdm/dotnetCore.ts"): string {
+// atomist:code-snippet:start=testysnippet
+const TestySnippet = "hooray, you found me";
+// atomist:code-snippet:end
+
+function generatorMarkdown(snippetName: string = "dotnetGenerator",
+                           sampleFilepath: string = "lib/sdm/dotnetCore.ts",
+                           sampleRepo: string = "atomist/samples"): string {
+    const repoSpec = sampleRepo === "atomist/samples" ? "" : `@${sampleRepo}`;
     return `
 
 # This is a sample docs page referencing a code snippet

--- a/test/machine/codeSnippetInline.test.ts
+++ b/test/machine/codeSnippetInline.test.ts
@@ -216,7 +216,7 @@ function parseSnippetReferences(p: Project, filename: string): SnippetReference[
     return results.map(match => toValueStructure<SnippetReference>(match));
 }
 
-// atomist:code-snippet:start=testysnippet
+// atomist:code-snippet:start=testysnippet@atomist/docs-sdm
 const TestySnippet = "hooray, you found me";
 // atomist:code-snippet:end
 
@@ -250,6 +250,7 @@ describe("microgrammar for parsing snippet reference", () => {
         assert.deepStrictEqual(valueStructure, {
             href: {
                 filepath: "lib/sdm/dotnetCore.ts",
+                repoRef: undefined,
                 snippetName: "snippetypoo",
             },
             middle: `\`\`\`typescript


### PR DESCRIPTION
Based on some pairing with @jessitron we're going to start accepting repository samples in repos outside of `atomist/samples`.

I had a bit of trouble getting that test going until Jess pointed out that there's a bit of self-referentiality, so this PR is introducing a string of text (`atomist:code-snippet:start=testysnippet@atomist/docs-sdm`) that can then be consumed by the full feature-work/test in another branch. All this PR does is prep the grammar and the test otherwise.